### PR TITLE
Make master SauceException and Toss Trait

### DIFF
--- a/src/Exception/SauceException.php
+++ b/src/Exception/SauceException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Fk\Sauce\Exception;
+
+use Exception;
+use Fk\Sauce\Exception\Traits\{
+    Generate,
+    Problem,
+    Toss
+};
+
+class SauceException extends Exception
+{
+    use Generate, Problem, Toss;
+}

--- a/src/Exception/Traits/Toss.php
+++ b/src/Exception/Traits/Toss.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Fk\Sauce\Exception\Traits;
+
+use Exception;
+
+trait Toss
+{
+    /**
+     * Help the chaining method to return \Exception instance by default.
+     * 
+     * @return \Exception
+     */
+    public function toss() : Exception
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
Toss trait is very helpful to return \Exception instance itself for further use / throwing, hence the name.